### PR TITLE
Add Output Formats Support For Find Firebase Auth User Commands

### DIFF
--- a/cmd/byPhone.go
+++ b/cmd/byPhone.go
@@ -2,11 +2,14 @@ package cmd
 
 import (
 	"context"
+	"fmt"
 	"os"
 
+	fAuth "firebase.google.com/go/auth"
 	"github.com/mainawycliffe/kamanda/firebase"
 	"github.com/mainawycliffe/kamanda/firebase/auth"
 	"github.com/mainawycliffe/kamanda/utils"
+	"github.com/mainawycliffe/kamanda/views"
 	"github.com/spf13/cobra"
 )
 
@@ -17,12 +20,27 @@ var byPhoneCmd = &cobra.Command{
 	Short:   "find a Firebase Auth User by their phone number",
 	Example: `kamanda auth find by-phone +254712345678`,
 	Run: func(cmd *cobra.Command, args []string) {
+		output, err := cmd.Flags().GetString("output")
+		if err != nil {
+			utils.StdOutError(os.Stderr, "Error reading output: %s", err.Error())
+			os.Exit(1)
+		}
+		if output != "json" && output != "yaml" && output != "" {
+			utils.StdOutError(os.Stderr, "Unsupported output!")
+			os.Exit(1)
+		}
+		// args = list of uids
+		if len(args) == 0 {
+			utils.StdOutError(os.Stderr, "at least one Firebase user UID is required!")
+			os.Exit(1)
+		}
 		// args = list of phone numbers
 		if len(args) == 0 {
 			utils.StdOutError(os.Stderr, "at least one Firebase user UID is required!")
 			os.Exit(1)
 		}
 		criteria := auth.ByUserUIDCriteria
+		users := make([]*fAuth.ExportedUserRecord, 0)
 		for _, phone := range args {
 			user, err := auth.GetUser(context.Background(), phone, criteria)
 			if err != nil {
@@ -33,9 +51,21 @@ var byPhoneCmd = &cobra.Command{
 				utils.StdOutError(os.Stderr, "Error\t%s\t%s", phone, err.Error())
 				continue
 			}
-			// @todo expand this list of users
-			utils.StdOutSuccess(os.Stdout, "%s\tWas successfully Retrieved\n", user.UID)
+			users = append(users, &fAuth.ExportedUserRecord{
+				UserRecord: user,
+			})
 		}
+		formatedUsers, err := utils.FormatResults(users, output)
+		if err != nil && err.Error() != "Unknown Format" {
+			utils.StdOutError(os.Stderr, "%s\n", err.Error())
+			os.Exit(1)
+		}
+		if formatedUsers != nil {
+			fmt.Printf("%s\n", formatedUsers)
+			os.Exit(0)
+		}
+		// draw table
+		views.ViewUsersTable(users, "")
 		os.Exit(0)
 	},
 }

--- a/cmd/findUser.go
+++ b/cmd/findUser.go
@@ -48,12 +48,10 @@ To find user by email or by phone use "find by-email" or "find by-phone"`,
 				utils.StdOutError(os.Stderr, "Error \t %s \t %s", uid, err.Error())
 				continue
 			}
-			//@todo something with the output
 			users = append(users, &fAuth.ExportedUserRecord{
 				UserRecord: user,
 			})
 		}
-
 		formatedUsers, err := utils.FormatResults(users, output)
 		if err != nil && err.Error() != "Unknown Format" {
 			utils.StdOutError(os.Stderr, "%s\n", err.Error())

--- a/cmd/findUser.go
+++ b/cmd/findUser.go
@@ -2,11 +2,14 @@ package cmd
 
 import (
 	"context"
+	"fmt"
 	"os"
 
+	fAuth "firebase.google.com/go/auth"
 	"github.com/mainawycliffe/kamanda/firebase"
 	"github.com/mainawycliffe/kamanda/firebase/auth"
 	"github.com/mainawycliffe/kamanda/utils"
+	"github.com/mainawycliffe/kamanda/views"
 	"github.com/spf13/cobra"
 )
 
@@ -19,12 +22,22 @@ var findUserCmd = &cobra.Command{
 To find user by email or by phone use "find by-email" or "find by-phone"`,
 	Example: `kamanda auth find [UID1] [UID2]`,
 	Run: func(cmd *cobra.Command, args []string) {
+		output, err := cmd.Flags().GetString("output")
+		if err != nil {
+			utils.StdOutError(os.Stderr, "Error reading output: %s", err.Error())
+			os.Exit(1)
+		}
+		if output != "json" && output != "yaml" && output != "" {
+			utils.StdOutError(os.Stderr, "Unsupported output!")
+			os.Exit(1)
+		}
 		// args = list of uids
 		if len(args) == 0 {
 			utils.StdOutError(os.Stderr, "at least one Firebase user UID is required!")
 			os.Exit(1)
 		}
 		criteria := auth.ByUserUIDCriteria
+		users := make([]*fAuth.ExportedUserRecord, 0)
 		for _, uid := range args {
 			user, err := auth.GetUser(context.Background(), uid, criteria)
 			if err != nil {
@@ -36,8 +49,22 @@ To find user by email or by phone use "find by-email" or "find by-phone"`,
 				continue
 			}
 			//@todo something with the output
-			utils.StdOutSuccess(os.Stdout, "Success \t %s \t Was successfully Retrieved", user.UID)
+			users = append(users, &fAuth.ExportedUserRecord{
+				UserRecord: user,
+			})
 		}
+
+		formatedUsers, err := utils.FormatResults(users, output)
+		if err != nil && err.Error() != "Unknown Format" {
+			utils.StdOutError(os.Stderr, "%s\n", err.Error())
+			os.Exit(1)
+		}
+		if formatedUsers != nil {
+			fmt.Printf("%s\n", formatedUsers)
+			os.Exit(0)
+		}
+		// draw table
+		views.ViewUsersTable(users, "")
 		os.Exit(0)
 	},
 }


### PR DESCRIPTION
Closes #5 

This required that the commands used to find users should have the same output as the `kamanda auth list-users` command.